### PR TITLE
Removed enableFeaturePreview(VERSION_CATALOGS)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -47,8 +47,3 @@ settingsDir.traverse(nameFilter: "build.gradle") {
 println("Included samples: $samples")
 include(*samples)
 gradle.ext.samples = samples
-
-
-// Enable Gradle's version catalog support
-// https://docs.gradle.org/current/userguide/platforms.html
-enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
- Removed `enableFeaturePreview("VERSION_CATALOGS")` because Version catalogs is stable from Gradle 7.4.
  - https://docs.gradle.org/7.4/release-notes.html#:~:text=a%20stable%20feature.-,Version%20catalogs,-Version%20catalogs%20is