### PR TITLE
Add @Deprecated annotation support

### DIFF
--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/DeprecatedSample.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/DeprecatedSample.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.catalog.app.multiple
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.google.android.catalog.framework.annotations.Sample
+
+@Deprecated(
+    message = "Example of a deprecated sample that won't appear in the app.",
+    replaceWith = ReplaceWith("FirstSample"),
+)
+@Sample(name = "Deprecated sample", "Shows how a sample can be deprecated")
+@Composable
+fun DeprecatedSample() {
+    Box(Modifier.fillMaxSize()) {
+        Text(text = "Hi, you won't see me!")
+    }
+}

--- a/framework/processor/src/main/java/com/google/android/catalog/framework/processor/SampleProcessor.kt
+++ b/framework/processor/src/main/java/com/google/android/catalog/framework/processor/SampleProcessor.kt
@@ -20,6 +20,7 @@ import com.google.android.catalog.framework.annotations.Sample
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
@@ -53,7 +54,11 @@ class SampleProcessor(
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getSymbolsWithAnnotation(Sample::class.java.name)
-            .filter { (it is KSFunctionDeclaration || it is KSClassDeclaration) && it.validate() }
+            .filter {
+                (it is KSFunctionDeclaration || it is KSClassDeclaration) &&
+                    it.validate() &&
+                    !it.isAnnotationPresent(Deprecated::class)
+            }
             .forEach { it.accept(visitor, Unit) }
 
         return emptyList()
@@ -67,6 +72,7 @@ class SampleProcessor(
             ) {
                 "@Sample must be a in a Composable function with empty parameters"
             }
+
             createModule(
                 functionSample = declaration,
                 target = "targetComposable { ${declaration.toFullPath()}() }"


### PR DESCRIPTION
When a sample is annotated with @Deprecated it won't be included in the main app.

This enables gracefully deprecation of samples:

1. Providing a reason
2. Avoid showing it in the main app

Eventually a @Deprecated sample should be removed.
