### PR TITLE
Support @RequireApi annotation

### DIFF
--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SecondSample.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SecondSample.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.catalog.app.multiple
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -29,9 +31,10 @@ import com.google.android.catalog.framework.annotations.Sample
     tags = ["tag1"],
     owners = ["owner1"]
 )
+@RequiresApi(Build.VERSION_CODES.S)
 @Composable
 fun SecondSample() {
     Box(Modifier.fillMaxSize()) {
-        Text(text = "Hi, I am the Second sample!")
+        Text(text = "Hi, I am the Second sample only available in Android 12!")
     }
 }

--- a/framework/base/api/current.api
+++ b/framework/base/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.catalog.framework.base {
 
   public final class CatalogSample {
-    ctor public CatalogSample(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target, optional int minSDK);
+    ctor public CatalogSample(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target);
     method public String component1();
     method public String component2();
     method public java.util.List<java.lang.String> component3();
@@ -11,11 +11,9 @@ package com.google.android.catalog.framework.base {
     method public String component6();
     method public java.util.List<java.lang.String> component7();
     method public com.google.android.catalog.framework.base.CatalogTarget component8();
-    method public int component9();
-    method public com.google.android.catalog.framework.base.CatalogSample copy(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target, int minSDK);
+    method public com.google.android.catalog.framework.base.CatalogSample copy(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target);
     method public String getDescription();
     method public String getDocumentation();
-    method public int getMinSDK();
     method public String getName();
     method public java.util.List<java.lang.String> getOwners();
     method public String getPath();
@@ -24,7 +22,6 @@ package com.google.android.catalog.framework.base {
     method public com.google.android.catalog.framework.base.CatalogTarget getTarget();
     property public final String description;
     property public final String documentation;
-    property public final int minSDK;
     property public final String name;
     property public final java.util.List<java.lang.String> owners;
     property public final String path;

--- a/framework/base/api/current.api
+++ b/framework/base/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.catalog.framework.base {
 
   public final class CatalogSample {
-    ctor public CatalogSample(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target);
+    ctor public CatalogSample(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target, optional int minSDK);
     method public String component1();
     method public String component2();
     method public java.util.List<java.lang.String> component3();
@@ -11,9 +11,11 @@ package com.google.android.catalog.framework.base {
     method public String component6();
     method public java.util.List<java.lang.String> component7();
     method public com.google.android.catalog.framework.base.CatalogTarget component8();
-    method public com.google.android.catalog.framework.base.CatalogSample copy(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target);
+    method public int component9();
+    method public com.google.android.catalog.framework.base.CatalogSample copy(String name, String description, java.util.List<java.lang.String> tags, String documentation, String sourcePath, String path, java.util.List<java.lang.String> owners, com.google.android.catalog.framework.base.CatalogTarget target, int minSDK);
     method public String getDescription();
     method public String getDocumentation();
+    method public int getMinSDK();
     method public String getName();
     method public java.util.List<java.lang.String> getOwners();
     method public String getPath();
@@ -22,6 +24,7 @@ package com.google.android.catalog.framework.base {
     method public com.google.android.catalog.framework.base.CatalogTarget getTarget();
     property public final String description;
     property public final String documentation;
+    property public final int minSDK;
     property public final String name;
     property public final java.util.List<java.lang.String> owners;
     property public final String path;

--- a/framework/base/src/main/java/com/google/android/catalog/framework/base/CatalogSample.kt
+++ b/framework/base/src/main/java/com/google/android/catalog/framework/base/CatalogSample.kt
@@ -24,5 +24,6 @@ data class CatalogSample(
     val sourcePath: String,
     val path: String,
     val owners: List<String>,
-    val target: CatalogTarget
+    val target: CatalogTarget,
+    val minSDK: Int = 0,
 )

--- a/framework/processor/build.gradle
+++ b/framework/processor/build.gradle
@@ -29,6 +29,7 @@ affectedTestConfiguration {
 
 dependencies {
     implementation(project(":framework:annotations"))
+    implementation libs.androidx.annotation
     implementation libs.google.ksp.api
 }
 

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
@@ -117,7 +117,12 @@ internal fun CatalogScreen(
                 }
             }
             items(displayedSamples) {
-                CardItem(it.name, it.description, it.tags) {
+                CardItem(
+                    label = it.name,
+                    description = it.description,
+                    tags = it.tags,
+                    minSDK = it.minSDK,
+                ) {
                     launchSample(it)
                     searchState = false
                 }

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.catalog.framework.ui.components
 
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -43,13 +44,16 @@ internal fun CardItem(
     label: String,
     description: String = "",
     tags: List<String> = emptyList(),
+    minSDK: Int = 0,
     onItemClick: () -> Unit
 ) {
+    val enabled = Build.VERSION.SDK_INT >= minSDK
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
-        onClick = onItemClick
+        enabled = enabled,
+        onClick = onItemClick,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -72,6 +76,19 @@ internal fun CardItem(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (!enabled) {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .clip(MaterialTheme.shapes.medium)
+                                .background(MaterialTheme.colorScheme.error.copy(alpha = 0.5f))
+                                .padding(6.dp),
+                            color = MaterialTheme.colorScheme.onError,
+                            style = MaterialTheme.typography.labelSmall,
+                            text = "minSDK=$minSDK",
+                        )
+                    }
+                }
                 items(tags) { tag ->
                     Text(
                         modifier = Modifier

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ google-ksp = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:1.7.
 google-ksp-api = "com.google.devtools.ksp:symbol-processing-api:1.7.20-1.0.8"
 
 androidx-core = "androidx.core:core-ktx:1.9.0"
+androidx-annotation = "androidx.annotation:annotation:1.5.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.5.4"
 androidx-activity = "androidx.activity:activity:1.6.1"
 androidx-activity-compose = "androidx.activity:activity-compose:1.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ composeCompiler = "1.3.2"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
-gradlePlugin = "8.0.0-alpha10"
+gradlePlugin = "7.3.1"
 lintMinCompose = "30.0.0"
 
 ktlint = "0.42.1"


### PR DESCRIPTION
- Find if a sample is annotated with @RequireApi
- Extract the minSDK out of it
- Use that information to disable the sample card

This allow samples to define API requirement without having to do the checks inside the sample entry-point.

![Screenshot_20230125_123836](https://user-images.githubusercontent.com/2639977/214554762-90c7887c-9554-424f-840e-2e861a38d41c.png)


