### PR TITLE
Enable deeplink by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ Each entry point will be automatically included in the main app and displayed fo
 
 ### Launch a specific sample
 
-To launch a specific sample from Android Studio you can pass the sample name via the `am start`
-command using the [-e](https://developer.android.com/studio/command-line/adb#IntentSpec)
-parameter using the
+To launch a specific sample from Android Studio you can pass the sample name or the sample path via
+the `am start` command using the [-e](https://developer.android.com/studio/command-line/adb#IntentSpec)
+parameter and the
 [CatalogActivity.KEY_START](framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt)
 key value.
 

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
@@ -60,10 +60,7 @@ open class CatalogActivity : FragmentActivity() {
         // Ensure that the declaring activity theme don't show an actionbar
         actionBar?.hide()
 
-        // Get the starting destination from the launching intent
-        val startDestination = intent.getStringExtra(KEY_START).orEmpty().ifBlank {
-            CATALOG_DESTINATION
-        }
+        val startDestination = getStartDestination()
 
         setContent {
             CatalogTheme {
@@ -79,5 +76,19 @@ open class CatalogActivity : FragmentActivity() {
                 }
             }
         }
+    }
+
+    /**
+     * Get the starting destination from the launching intent or the home screen if not found.
+     */
+    private fun getStartDestination(): String {
+        val value = intent.getStringExtra(KEY_START).orEmpty()
+        if (value.isEmpty()) {
+            return CATALOG_DESTINATION
+        }
+
+        return catalogSamples.find {
+            it.route == value || it.name.equals(value, ignoreCase = true)
+        }?.route ?: CATALOG_DESTINATION
     }
 }


### PR DESCRIPTION
Pass either the full route or the name to the sample in the deeplink to directly open it.
