### PR TITLE
Set @Sample retention to Runtime

### DIFF
--- a/framework/annotations/src/main/java/com/google/android/catalog/framework/annotations/Sample.kt
+++ b/framework/annotations/src/main/java/com/google/android/catalog/framework/annotations/Sample.kt
@@ -30,7 +30,7 @@ package com.google.android.catalog.framework.annotations
  * @param owners an optional owners information, it can be used to show who proposed the sample
  */
 @MustBeDocumented
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class Sample(
     val name: String,


### PR DESCRIPTION
To enable possible use-cases to search for samples in the binary or perform some sort of reflection at runtime we are changing the retention to RUNTIME.
