### PR TITLE
Support Large screen

### DIFF
--- a/app-catalog/app/src/main/java/com/google/android/catalog/app/MainActivity.kt
+++ b/app-catalog/app/src/main/java/com/google/android/catalog/app/MainActivity.kt
@@ -18,6 +18,10 @@ package com.google.android.catalog.app
 
 import android.app.Application
 import com.google.android.catalog.framework.ui.CatalogActivity
+import com.google.android.catalog.framework.ui.CatalogCardAppearance
+import com.google.android.catalog.framework.ui.CatalogFilter
+import com.google.android.catalog.framework.ui.CatalogOrder
+import com.google.android.catalog.framework.ui.CatalogSettings
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.HiltAndroidApp
 
@@ -25,4 +29,19 @@ import dagger.hilt.android.HiltAndroidApp
 class MainApp : Application()
 
 @AndroidEntryPoint
-class MainActivity : CatalogActivity()
+class MainActivity : CatalogActivity() {
+
+    /**
+     * You can optionally modify certain aspects of the catalog
+     */
+    override val settings = CatalogSettings(
+        filters = listOf(CatalogFilter.Path(), CatalogFilter.Tag),
+        order = CatalogOrder.Name(),
+        alwaysShowToolbar = true,
+        cardAppearance = CatalogCardAppearance(
+            description = 1,
+            tags = true,
+            owners = false
+        )
+    )
+}

--- a/app-catalog/samples/compose/src/main/java/com/google.android.catalog.app.compose/ComposeSample.kt
+++ b/app-catalog/samples/compose/src/main/java/com/google.android.catalog.app.compose/ComposeSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.catalog.framework.annotations.Sample
 
@@ -30,7 +31,7 @@ import com.google.android.catalog.framework.annotations.Sample
 )
 @Composable
 fun ComposeSample() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, I am a compose sample target!")
     }
 }

--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/DeprecatedSample.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/DeprecatedSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.catalog.framework.annotations.Sample
 
@@ -30,7 +31,7 @@ import com.google.android.catalog.framework.annotations.Sample
 @Sample(name = "Deprecated sample", "Shows how a sample can be deprecated")
 @Composable
 fun DeprecatedSample() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, you won't see me!")
     }
 }

--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/FirstSample.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/FirstSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.catalog.framework.annotations.Sample
 
@@ -31,7 +32,7 @@ import com.google.android.catalog.framework.annotations.Sample
 )
 @Composable
 fun FirstSample() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, I am the first sample!")
     }
 }

--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SameFileSamples.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SameFileSamples.kt
@@ -20,13 +20,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.catalog.framework.annotations.Sample
 
 @Sample(name = "Same file sample 1", "Show how a file can contain multiple samples")
 @Composable
 fun SameFileSample1() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, I am same file sample 1")
     }
 }
@@ -34,7 +35,7 @@ fun SameFileSample1() {
 @Sample(name = "Same file sample 2", "Show how a file can contain multiple samples")
 @Composable
 fun SameFileSample2() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, I am same file sample 2")
     }
 }

--- a/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SecondSample.kt
+++ b/app-catalog/samples/multiple/src/main/java/com/google.android.catalog.app.multiple/SecondSample.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.catalog.framework.annotations.Sample
 
@@ -34,7 +35,7 @@ import com.google.android.catalog.framework.annotations.Sample
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable
 fun SecondSample() {
-    Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = "Hi, I am the Second sample only available in Android 12!")
     }
 }

--- a/framework/ui/api/current.api
+++ b/framework/ui/api/current.api
@@ -4,8 +4,10 @@ package com.google.android.catalog.framework.ui {
   public class CatalogActivity extends androidx.fragment.app.FragmentActivity {
     ctor public CatalogActivity();
     method public final java.util.Set<com.google.android.catalog.framework.base.CatalogSample> getCatalogSamples();
+    method public com.google.android.catalog.framework.ui.CatalogSettings getSettings();
     method public final void setCatalogSamples(java.util.Set<com.google.android.catalog.framework.base.CatalogSample> catalogSamples);
     property public final java.util.Set<com.google.android.catalog.framework.base.CatalogSample> catalogSamples;
+    property public com.google.android.catalog.framework.ui.CatalogSettings settings;
     field public static final com.google.android.catalog.framework.ui.CatalogActivity.Companion Companion;
     field public static final String KEY_START = "start";
     field @javax.inject.Inject public java.util.Set<com.google.android.catalog.framework.base.CatalogSample> catalogSamples;
@@ -14,11 +16,83 @@ package com.google.android.catalog.framework.ui {
   public static final class CatalogActivity.Companion {
   }
 
+  public final class CatalogCardAppearance {
+    ctor public CatalogCardAppearance(optional int description, optional boolean tags, optional boolean owners);
+    method public int component1();
+    method public boolean component2();
+    method public boolean component3();
+    method public com.google.android.catalog.framework.ui.CatalogCardAppearance copy(int description, boolean tags, boolean owners);
+    method public int getDescription();
+    method public boolean getOwners();
+    method public boolean getTags();
+    property public final int description;
+    property public final boolean owners;
+    property public final boolean tags;
+  }
+
+  public sealed interface CatalogFilter {
+  }
+
+  public static final class CatalogFilter.Path implements com.google.android.catalog.framework.ui.CatalogFilter {
+    ctor public CatalogFilter.Path(optional int depth);
+    method public int component1();
+    method public com.google.android.catalog.framework.ui.CatalogFilter.Path copy(int depth);
+    method public int getDepth();
+    property public final int depth;
+  }
+
+  public static final class CatalogFilter.Tag implements com.google.android.catalog.framework.ui.CatalogFilter {
+    field public static final com.google.android.catalog.framework.ui.CatalogFilter.Tag INSTANCE;
+  }
+
   public final class CatalogNavigationKt {
-    method @androidx.compose.runtime.Composable public static void CatalogNavigation(String startDestination, java.util.Set<com.google.android.catalog.framework.base.CatalogSample> samples, androidx.fragment.app.FragmentManager fragmentManager);
+    method @androidx.compose.runtime.Composable public static void CatalogNavigation(String startDestination, java.util.Set<com.google.android.catalog.framework.base.CatalogSample> samples, com.google.android.catalog.framework.ui.CatalogSettings settings, androidx.fragment.app.FragmentManager fragmentManager);
+  }
+
+  public sealed interface CatalogOrder {
+  }
+
+  public static final class CatalogOrder.Custom implements com.google.android.catalog.framework.ui.CatalogOrder {
+    ctor public CatalogOrder.Custom(error.NonExistentClass comparator);
+    method public int compare(com.google.android.catalog.framework.base.CatalogSample sample1, com.google.android.catalog.framework.base.CatalogSample sample2);
+    method public error.NonExistentClass! component1();
+    method public com.google.android.catalog.framework.ui.CatalogOrder.Custom copy(error.NonExistentClass! comparator);
+    method public error.NonExistentClass! getComparator();
+    property public final error.NonExistentClass! comparator;
+  }
+
+  public static final class CatalogOrder.Name implements com.google.android.catalog.framework.ui.CatalogOrder {
+    ctor public CatalogOrder.Name(optional boolean asc);
+    method public int compare(com.google.android.catalog.framework.base.CatalogSample sample1, com.google.android.catalog.framework.base.CatalogSample sample2);
+    method public boolean component1();
+    method public com.google.android.catalog.framework.ui.CatalogOrder.Name copy(boolean asc);
+    method public boolean getAsc();
+    property public final boolean asc;
+  }
+
+  public static final class CatalogOrder.None implements com.google.android.catalog.framework.ui.CatalogOrder {
+    method public int compare(com.google.android.catalog.framework.base.CatalogSample sample1, com.google.android.catalog.framework.base.CatalogSample sample2);
+    field public static final com.google.android.catalog.framework.ui.CatalogOrder.None INSTANCE;
   }
 
   public final class CatalogScreenKt {
+  }
+
+  public final class CatalogSettings {
+    ctor public CatalogSettings(optional java.util.List<? extends com.google.android.catalog.framework.ui.CatalogFilter> filters, optional com.google.android.catalog.framework.ui.CatalogOrder order, optional boolean alwaysShowToolbar, optional com.google.android.catalog.framework.ui.CatalogCardAppearance cardAppearance);
+    method public java.util.List<com.google.android.catalog.framework.ui.CatalogFilter> component1();
+    method public com.google.android.catalog.framework.ui.CatalogOrder component2();
+    method public boolean component3();
+    method public com.google.android.catalog.framework.ui.CatalogCardAppearance component4();
+    method public com.google.android.catalog.framework.ui.CatalogSettings copy(java.util.List<? extends com.google.android.catalog.framework.ui.CatalogFilter> filters, com.google.android.catalog.framework.ui.CatalogOrder order, boolean alwaysShowToolbar, com.google.android.catalog.framework.ui.CatalogCardAppearance cardAppearance);
+    method public boolean getAlwaysShowToolbar();
+    method public com.google.android.catalog.framework.ui.CatalogCardAppearance getCardAppearance();
+    method public java.util.List<com.google.android.catalog.framework.ui.CatalogFilter> getFilters();
+    method public com.google.android.catalog.framework.ui.CatalogOrder getOrder();
+    property public final boolean alwaysShowToolbar;
+    property public final com.google.android.catalog.framework.ui.CatalogCardAppearance cardAppearance;
+    property public final java.util.List<com.google.android.catalog.framework.ui.CatalogFilter> filters;
+    property public final com.google.android.catalog.framework.ui.CatalogOrder order;
   }
 
 }

--- a/framework/ui/build.gradle
+++ b/framework/ui/build.gradle
@@ -96,7 +96,9 @@ dependencies {
     implementation libs.androidx.fragment
     implementation libs.androidx.navigation.compose
     implementation libs.compose.ui.ui
-    implementation libs.compose.material3
+    implementation libs.compose.material.material3
+    implementation libs.compose.material.window
+    implementation libs.compose.material.iconsext
 
     androidTestImplementation libs.androidx.test.runner
     testImplementation libs.androidx.test.runner

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
@@ -55,6 +55,13 @@ open class CatalogActivity : FragmentActivity() {
     @Inject
     lateinit var catalogSamples: Set<CatalogSample>
 
+    /**
+     * Override this field to customize the certain aspects of the UI.
+     *
+     * @see CatalogSettings
+     */
+    open val settings: CatalogSettings = CatalogSettings()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Ensure that the declaring activity theme don't show an actionbar
@@ -71,7 +78,8 @@ open class CatalogActivity : FragmentActivity() {
                     CatalogNavigation(
                         startDestination = startDestination,
                         samples = catalogSamples,
-                        fragmentManager = supportFragmentManager
+                        settings = settings,
+                        fragmentManager = supportFragmentManager,
                     )
                 }
             }

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogActivity.kt
@@ -21,9 +21,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import com.google.android.catalog.framework.base.CatalogSample
+import com.google.android.catalog.framework.ui.components.LocalWindowSize
 import com.google.android.catalog.framework.ui.theme.CatalogTheme
 import javax.inject.Inject
 
@@ -62,6 +66,7 @@ open class CatalogActivity : FragmentActivity() {
      */
     open val settings: CatalogSettings = CatalogSettings()
 
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Ensure that the declaring activity theme don't show an actionbar
@@ -75,12 +80,15 @@ open class CatalogActivity : FragmentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    CatalogNavigation(
-                        startDestination = startDestination,
-                        samples = catalogSamples,
-                        settings = settings,
-                        fragmentManager = supportFragmentManager,
-                    )
+                    val sizeClass = calculateWindowSizeClass(this)
+                    CompositionLocalProvider(LocalWindowSize provides sizeClass) {
+                        CatalogNavigation(
+                            startDestination = startDestination,
+                            samples = catalogSamples,
+                            settings = settings,
+                            fragmentManager = supportFragmentManager
+                        )
+                    }
                 }
             }
         }

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogNavigation.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogNavigation.kt
@@ -41,6 +41,7 @@ import com.google.android.catalog.framework.ui.components.FragmentContainer
 fun CatalogNavigation(
     startDestination: String,
     samples: Set<CatalogSample>,
+    settings: CatalogSettings,
     fragmentManager: FragmentManager
 ) {
     val navController = rememberNavController()
@@ -51,14 +52,14 @@ fun CatalogNavigation(
     ) {
         // Add the home destination
         composable(CATALOG_DESTINATION) {
-            CatalogScreen(samples.toList()) {
+            CatalogScreen(samples.toList(), settings) {
                 navController.navigate(it.route)
             }
         }
 
         // Add all the samples
         samples.forEach { sample ->
-            addTargets(sample, fragmentManager) {
+            addTargets(sample, fragmentManager, settings) {
                 navController.popBackStack()
             }
         }
@@ -68,12 +69,13 @@ fun CatalogNavigation(
 private fun NavGraphBuilder.addTargets(
     sample: CatalogSample,
     fragmentManager: FragmentManager,
+    settings: CatalogSettings,
     onBackClick: () -> Unit
 ) {
     when (val target = sample.target) {
         is CatalogTarget.TargetComposable -> {
             composable(sample.route) {
-                SampleScaffold(sample = sample, onBackClick = onBackClick) {
+                SampleScaffold(sample = sample, settings = settings, onBackClick = onBackClick) {
                     target.composable()
                 }
             }
@@ -81,7 +83,7 @@ private fun NavGraphBuilder.addTargets(
 
         is CatalogTarget.TargetFragment -> {
             composable(sample.route) {
-                SampleScaffold(sample = sample, onBackClick = onBackClick) {
+                SampleScaffold(sample = sample, settings = settings, onBackClick = onBackClick) {
                     FragmentContainer(
                         modifier = Modifier.fillMaxSize(),
                         fragmentManager = fragmentManager,
@@ -106,14 +108,17 @@ private fun NavGraphBuilder.addTargets(
 @OptIn(ExperimentalMaterial3Api::class)
 private fun SampleScaffold(
     sample: CatalogSample,
+    settings: CatalogSettings,
     onBackClick: () -> Unit,
     content: @Composable BoxScope.() -> Unit
 ) {
     Scaffold(
         topBar = {
-            CatalogTopAppBar(
-                selectedSample = sample, onBackClick = onBackClick
-            )
+            if (settings.alwaysShowToolbar) {
+                CatalogTopAppBar(
+                    selectedSample = sample, onBackClick = onBackClick
+                )
+            }
         },
     ) { contentPadding ->
         Box(modifier = Modifier.padding(contentPadding), content = content)

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogNavigation.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogNavigation.kt
@@ -45,6 +45,7 @@ fun CatalogNavigation(
     fragmentManager: FragmentManager
 ) {
     val navController = rememberNavController()
+
     NavHost(
         modifier = Modifier.background(MaterialTheme.colorScheme.background),
         navController = navController,
@@ -59,9 +60,13 @@ fun CatalogNavigation(
 
         // Add all the samples
         samples.forEach { sample ->
-            addTargets(sample, fragmentManager, settings) {
-                navController.popBackStack()
-            }
+            addTargets(
+                sample = sample,
+                fragmentManager = fragmentManager,
+                settings = settings,
+                onExpand = { navController.navigate(it.route) },
+                onBackClick = navController::popBackStack
+            )
         }
     }
 }
@@ -70,12 +75,18 @@ private fun NavGraphBuilder.addTargets(
     sample: CatalogSample,
     fragmentManager: FragmentManager,
     settings: CatalogSettings,
-    onBackClick: () -> Unit
+    onExpand: (CatalogSample) -> Unit,
+    onBackClick: () -> Unit,
 ) {
     when (val target = sample.target) {
         is CatalogTarget.TargetComposable -> {
             composable(sample.route) {
-                SampleScaffold(sample = sample, settings = settings, onBackClick = onBackClick) {
+                SampleScaffold(
+                    sample = sample,
+                    settings = settings,
+                    onExpand = { onExpand(sample) },
+                    onBackClick = onBackClick,
+                ) {
                     target.composable()
                 }
             }
@@ -83,7 +94,12 @@ private fun NavGraphBuilder.addTargets(
 
         is CatalogTarget.TargetFragment -> {
             composable(sample.route) {
-                SampleScaffold(sample = sample, settings = settings, onBackClick = onBackClick) {
+                SampleScaffold(
+                    sample = sample,
+                    settings = settings,
+                    onExpand = { onExpand(sample) },
+                    onBackClick = onBackClick
+                ) {
                     FragmentContainer(
                         modifier = Modifier.fillMaxSize(),
                         fragmentManager = fragmentManager,
@@ -109,14 +125,18 @@ private fun NavGraphBuilder.addTargets(
 private fun SampleScaffold(
     sample: CatalogSample,
     settings: CatalogSettings,
+    onExpand: () -> Unit,
     onBackClick: () -> Unit,
-    content: @Composable BoxScope.() -> Unit
+    content: @Composable() (BoxScope.() -> Unit)
 ) {
     Scaffold(
         topBar = {
             if (settings.alwaysShowToolbar) {
                 CatalogTopAppBar(
-                    selectedSample = sample, onBackClick = onBackClick
+                    isDualPane = false,
+                    selectedSample = sample,
+                    onExpand = onExpand,
+                    onBackClick = onBackClick
                 )
             }
         },

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
@@ -17,6 +17,7 @@
 package com.google.android.catalog.framework.ui
 
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -166,6 +167,7 @@ private fun SamplesList(
             CardItem(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .animateItemPlacement(spring())
                     .padding(horizontal = 16.dp),
                 label = it.name,
                 appearance = appearance,

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogSettings.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogSettings.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.catalog.framework.ui
+
+import com.google.android.catalog.framework.base.CatalogSample
+
+/**
+ * Defines certain behavior for the Catalog app UI.
+ *
+ * @param filters a list of filters to include in the home top bar
+ * @param order the order to use when sorting the catalog samples list
+ * @param alwaysShowToolbar true to show the toolbar inside the samples or false to hide it
+ */
+data class CatalogSettings(
+    val filters: List<CatalogFilter> = listOf(CatalogFilter.Path(), CatalogFilter.Tag),
+    val order: CatalogOrder = CatalogOrder.Name(),
+    val alwaysShowToolbar: Boolean = true,
+    val cardAppearance: CatalogCardAppearance = CatalogCardAppearance(),
+)
+
+/**
+ * Defines the comparator to use when sorting the list of samples for the main screen
+ */
+sealed interface CatalogOrder : Comparator<CatalogSample> {
+
+    /**
+     * No order, use the auto-generated one
+     */
+    object None : CatalogOrder {
+        override fun compare(sample1: CatalogSample, sample2: CatalogSample): Int = 0
+    }
+
+    /**
+     * Order samples by name (ascending by default)
+     *
+     * @param asc true to order them ascending, false otherwise
+     */
+    data class Name(val asc: Boolean = true) : CatalogOrder {
+        override fun compare(sample1: CatalogSample, sample2: CatalogSample): Int {
+            val compareBy = compareBy<CatalogSample> { it.name }.run {
+                if (asc) this
+                else this.reversed()
+            }
+            return compareBy.compare(sample1, sample2)
+        }
+    }
+
+    /**
+     * Define your own comparator
+     *
+     * @param comparator the comparator to use when ordering the list of CatalogSample
+     */
+    data class Custom(val comparator: Comparator<CatalogSample>) : CatalogOrder {
+        override fun compare(
+            sample1: CatalogSample,
+            sample2: CatalogSample
+        ): Int = comparator.compare(sample1, sample2)
+    }
+}
+
+/**
+ * Define a type of filter to show in the top bar in the home screen
+ */
+sealed interface CatalogFilter {
+
+    /**
+     * Enables filter by sample path (by default only module root)
+     *
+     * @param depth the depth of the path (e.g depth = 1 would include the first layer of subfolder)
+     */
+    data class Path(val depth: Int = 0) : CatalogFilter
+
+    /**
+     * Enables filter by tag specified by the samples.
+     */
+    object Tag : CatalogFilter
+}
+
+/**
+ * Defines the appearance of the catalog lists cards
+ *
+ * @param description defines the amount of lines the description can take. No limit by default.
+ * @param tags show or not the tags
+ * @param owners show or not the owners
+ */
+data class CatalogCardAppearance(
+    val description: Int = Int.MAX_VALUE,
+    val tags: Boolean = true,
+    val owners: Boolean = true
+)

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
@@ -36,22 +36,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.google.android.catalog.framework.ui.CatalogCardAppearance
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun CardItem(
+    modifier: Modifier = Modifier,
     label: String,
+    appearance: CatalogCardAppearance,
     description: String = "",
     tags: List<String> = emptyList(),
+    owners: List<String> = emptyList(),
     minSDK: Int = 0,
     onItemClick: () -> Unit
 ) {
     val enabled = Build.VERSION.SDK_INT >= minSDK
     ElevatedCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+        modifier = modifier,
         enabled = enabled,
         onClick = onItemClick,
     ) {
@@ -66,12 +69,16 @@ internal fun CardItem(
                 Text(text = label, style = MaterialTheme.typography.labelLarge)
                 Icon(Icons.Rounded.KeyboardArrowRight, "Forward")
             }
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp),
-                text = description
-            )
+            if (appearance.description > 0) {
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp),
+                    text = description,
+                    maxLines = appearance.description,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
             LazyRow(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically
@@ -89,16 +96,31 @@ internal fun CardItem(
                         )
                     }
                 }
-                items(tags) { tag ->
-                    Text(
-                        modifier = Modifier
-                            .clip(MaterialTheme.shapes.medium)
-                            .background(MaterialTheme.colorScheme.primary)
-                            .padding(6.dp),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.labelSmall,
-                        text = tag
-                    )
+                if (appearance.tags) {
+                    items(tags) { tag ->
+                        Text(
+                            modifier = Modifier
+                                .clip(MaterialTheme.shapes.medium)
+                                .background(MaterialTheme.colorScheme.primary)
+                                .padding(6.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            style = MaterialTheme.typography.labelSmall,
+                            text = tag
+                        )
+                    }
+                }
+                if (appearance.owners) {
+                    items(owners) { owner ->
+                        Text(
+                            modifier = Modifier
+                                .clip(MaterialTheme.shapes.medium)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                                .padding(6.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.labelSmall,
+                            text = owner
+                        )
+                    }
                 }
             }
         }

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CardItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.KeyboardArrowRight
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -50,12 +51,20 @@ internal fun CardItem(
     tags: List<String> = emptyList(),
     owners: List<String> = emptyList(),
     minSDK: Int = 0,
+    selected: Boolean,
     onItemClick: () -> Unit
 ) {
     val enabled = Build.VERSION.SDK_INT >= minSDK
     ElevatedCard(
         modifier = modifier,
         enabled = enabled,
+        colors = if (selected) {
+            CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
+            )
+        } else {
+            CardDefaults.elevatedCardColors()
+        },
         onClick = onItemClick,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CompositionLocals.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/components/CompositionLocals.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.catalog.framework.ui.components
+
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalWindowSize = compositionLocalOf<WindowSizeClass> { error("No window size calculated") }
+
+@Composable
+fun isExpandedScreen() = LocalWindowSize.current.widthSizeClass == WindowWidthSizeClass.Expanded

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,9 +55,10 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-runtime-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
-compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-material = { module = "androidx.compose.material:material" }
 compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended" }
+compose-material-window = { module = "androidx.compose.material3:material3-window-size-class" }
 compose-animation-animation = { module = "androidx.compose.animation:animation" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/gradle/sample-build.gradle
+++ b/gradle/sample-build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation libs.androidx.core
     implementation libs.compose.foundation.foundation
     implementation libs.compose.ui.ui
-    implementation libs.compose.material3
+    implementation libs.compose.material.material3
 
     androidTestImplementation libs.androidx.test.runner
     testImplementation libs.androidx.test.runner


### PR DESCRIPTION
Add large screen support

Create an adaptive dual-pane that will show a list-detail screen with the list of samples and the selected sample.

Currently only Composable samples support that, for the rest it will expand to full screen.

This allows better navigation and creates a great experience for large screens.

In addition launch URL into multi-window mode when in large screen to allow side-by-side view with the code and the selected sample.

https://user-images.githubusercontent.com/2639977/222693799-724885b3-983e-4146-aac8-d0b211507611.mp4



