### PR TITLE
Skip field validation

### DIFF
--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
@@ -111,7 +111,6 @@ internal fun CatalogScreen(
                 selectedFilters.isEmpty() ||
                     selectedFilters.any { sample.path.contains(it) } ||
                     sample.tags.any { selectedFilters.contains(it) }
-
             }.filter { sample ->
                 searchTerm.isBlank() ||
                     sample.name.contains(searchTerm, ignoreCase = true) ||

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/CatalogScreen.kt
@@ -108,15 +108,15 @@ internal fun CatalogScreen(
     val displayedSamples by remember(searchTerm, selectedFilters) {
         derivedStateOf {
             catalogSamples.filter { sample ->
-                if (searchTerm.isBlank()) {
-                    selectedFilters.isEmpty() ||
-                        selectedFilters.any { sample.path.contains(it) } ||
-                        sample.tags.any { selectedFilters.contains(it) }
-                } else {
+                selectedFilters.isEmpty() ||
+                    selectedFilters.any { sample.path.contains(it) } ||
+                    sample.tags.any { selectedFilters.contains(it) }
+
+            }.filter { sample ->
+                searchTerm.isBlank() ||
                     sample.name.contains(searchTerm, ignoreCase = true) ||
-                        sample.description.contains(searchTerm, ignoreCase = true) ||
-                        sample.tags.any { it.equals(searchTerm, ignoreCase = true) }
-                }
+                    sample.description.contains(searchTerm, ignoreCase = true) ||
+                    sample.tags.any { it.equals(searchTerm, ignoreCase = true) }
             }.sortedWith(catalogSettings.order)
         }
     }


### PR DESCRIPTION
Skip class field validation to fix viewBinding issue

When using viewBinding as a field in a class KSP cannot resolve the type
and make the validation fail, skipping the class.

We don't need to check the class fields, so let's just skip it. 

Note: There might be a better way to do that