### PR TITLE
Fix same file sample route

### DIFF
--- a/framework/processor/src/main/java/com/google/android/catalog/framework/processor/SampleProcessor.kt
+++ b/framework/processor/src/main/java/com/google/android/catalog/framework/processor/SampleProcessor.kt
@@ -148,7 +148,7 @@ class SampleProcessor(
                     sampleOwners = sample.owners,
                     sampleTarget = target,
                     sampleMinSdk = minSDK,
-                    sampleRoute = "$sampleSource#$sampleFile",
+                    sampleRoute = "$sampleSource-$sampleFile",
                 ).toByteArray()
             )
         }


### PR DESCRIPTION
Using the # seems to filter anything after that so the route for two samples in the same file would be the same route.
