### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -126,7 +126,7 @@ jobs:
           if [ "$API_LEVEL" -ge "28" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           if [ "$API_LEVEL" -ge "28" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,7 +59,7 @@ jobs:
           if [ "$API_LEVEL" -ge "29" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: Run device tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
### Description

Closes #44 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=TARGET::$TARGET"
```

**TO-BE**

```yaml
echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
```