### PR TITLE
Expose CatalogTheme

### DIFF
--- a/framework/ui/api/current.api
+++ b/framework/ui/api/current.api
@@ -130,6 +130,7 @@ package com.google.android.catalog.framework.ui.theme {
   }
 
   public final class ThemeKt {
+    method @androidx.compose.runtime.Composable public static void CatalogTheme(optional boolean darkTheme, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
 }

--- a/framework/ui/src/main/java/com/google/android/catalog/framework/ui/theme/Theme.kt
+++ b/framework/ui/src/main/java/com/google/android/catalog/framework/ui/theme/Theme.kt
@@ -48,8 +48,12 @@ private val CatalogLightColorScheme = lightColorScheme(
     background = Color(0xFFFcFcFc),
 )
 
+/**
+ * Used by the CatalogActivity but you can also use it for any sample activity to match the same
+ * theme.
+ */
 @Composable
-internal fun CatalogTheme(
+fun CatalogTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {


### PR DESCRIPTION
This will allow samples targeting an activity to keep the same theme as the rest of the app.
